### PR TITLE
feat: finish support for indexing strings

### DIFF
--- a/book/src/reference/basic-types.md
+++ b/book/src/reference/basic-types.md
@@ -80,6 +80,17 @@ let poem = "this string has
 multiple lines!"; // -> "this string has\nmultiple lines!"
 ```
 
+Index a string with an `int` to read the character at that position. Positions count characters rather than bytes, so they line up with `len()` and with `for c in s`. Reading past the end is a runtime error, and since strings are immutable, assigning into an index is a compile error.
+
+```mimas
+let word = "café";
+let first = word[0];              // -> "c"
+let last = word[word.len() - 1];  // -> "é"
+word[0] = "C";                    // compile error: strings can't be assigned into
+```
+
+Indexing a string that is entirely ASCII is constant-time; a string holding any other characters is scanned from the start.
+
 ### Interpolation (f-strings)
 
 Prefix a literal with `f` to interpolate expressions inside `{ }`. Any expression is allowed.

--- a/crates/library/tests/str.rs
+++ b/crates/library/tests/str.rs
@@ -19,6 +19,41 @@ test_run!(
     r#""👍".len()"# => "1",
 );
 
+test_run!(
+    index_basic,
+    r#""hello"[0]"# => r#""h""#,
+    r#""hello"[4]"# => r#""o""#,
+);
+
+test_run!(
+    index_unicode,
+    r#""café"[3]"# => r#""é""#,
+    r#""👍abc"[1]"# => r#""a""#,
+    r#""aé漢b"[2]"# => r#""漢""#,
+);
+
+test_run!(
+    index_matches_iteration,
+    r#"let s = "héllo";"#,
+    r#"(for i in s.len() collect s[i]).join("")"# => r#""héllo""#,
+);
+
+test_run!(
+    index_optional,
+    r#"let some: str? = "xy"; let none: str? = null;"#,
+    "some?[1]" => r#""y""#,
+    "none?[0]" => "null",
+);
+
+test_fail!(
+    index_out_of_bounds,
+    r#"let c = "abc"[3];"#,
+    r#"let c = "abc"[-1];"#,
+    r#"let c = "é"[1];"#,
+);
+
+test_fail!(index_assign, r#"let s = "abc"; s[0] = "x";"#);
+
 // contains: substring test
 test_run!(
     contains_hit,

--- a/crates/solve/src/errors.rs
+++ b/crates/solve/src/errors.rs
@@ -233,16 +233,26 @@ pub struct NotAPact {
     pub ty: String,
 }
 
-/// `s[0]` on a string. Its own error because the generic index path would otherwise report a
-/// mismatch against a freshly minted element vid, putting an internal `?mimas<T>` in front of a
-/// user who only wanted a character.
+/// `s["k"]` on a string. Its own error because the generic index path would otherwise report a
+/// mismatch against a freshly minted element vid, putting an internal `?mimas<T>` in front of the
+/// user.
 #[derive(Error, Debug, Diagnostic)]
-#[error("strings can't be indexed")]
-#[diagnostic(help("iterate the characters with `for c in s` instead"))]
+#[error("strings are indexed by int")]
+#[diagnostic(help("index with a character position, like `s[0]`"))]
 pub struct StringIndexing {
     #[source_code]
     pub src: NamedSource<Arc<str>>,
-    #[label("indexing is for arrays and dicts")]
+    #[label("this key isn't an int")]
+    pub at: SourceSpan,
+}
+
+#[derive(Error, Debug, Diagnostic)]
+#[error("strings can't be assigned into")]
+#[diagnostic(help("strings are immutable -- build a new string instead"))]
+pub struct AssignToStringIndex {
+    #[source_code]
+    pub src: NamedSource<Arc<str>>,
+    #[label("this string can't be changed in place")]
     pub at: SourceSpan,
 }
 

--- a/crates/solve/src/solver.rs
+++ b/crates/solve/src/solver.rs
@@ -2,8 +2,8 @@ use crate::{
     Error, Result, Unification, UnificationError,
     components::*,
     errors::{
-        AssignToConst, AssignToLoopVar, BareNullBinding, ExtraTupleMembers, FieldNotFound,
-        InvalidAssignTarget, InvalidPattern, InvalidUseTarget, MissingTupleMembers,
+        AssignToConst, AssignToLoopVar, AssignToStringIndex, BareNullBinding, ExtraTupleMembers,
+        FieldNotFound, InvalidAssignTarget, InvalidPattern, InvalidUseTarget, MissingTupleMembers,
         MultipleConstDeclarations, NonConstantValue, NotFound, SelfOutOfContext,
     },
     traits::*,
@@ -1480,6 +1480,18 @@ impl Solver {
                         })?
                     }
                     _ => {}
+                }
+
+                if let ExprKind::Access(Access::Square { left: receiver, .. }) = left.kind() {
+                    let receiver = receiver.query(self)?.normalized(self);
+                    if receiver == Ty::Str
+                        || matches!(&receiver, Ty::Option(inner) if **inner == Ty::Str)
+                    {
+                        Err(AssignToStringIndex {
+                            src: self.src(left.location()),
+                            at: left.location().into(),
+                        })?
+                    }
                 }
 
                 // `??=` mirrors read-form `??`: the target must be an option and the rhs

--- a/crates/solve/src/tests/solve_exprs.rs
+++ b/crates/solve/src/tests/solve_exprs.rs
@@ -480,7 +480,7 @@ test_fail!(
     "let a: (int, int) = (0, 1, 2);",
 );
 test_fail!(index_assign_mismatch, "let a = [0]; a[0] = \"x\";");
-test_fail!(string_square_index, "let s = \"hi\"; let c = s[0];");
+test_ty!(string_square_index, "let s = \"hi\";", "s[0]" => Str);
 test_fail!(for_iter_elem_used_wrong, "for x in [0] { let y: str = x; }");
 test_fail!(while_cond_non_bool, "while 5 {}");
 test_fail!(logical_rhs_non_bool, "let x = true && 2;");
@@ -549,10 +549,13 @@ test_fail!(
     "for x in [] { collect 0; break 5; }",
 );
 
-// `s[0]` gets its own error rather than a mismatch against the index path's fresh element
-// vid, which used to put an internal `?mimas<T>` in a message about the user's own code
-test_fail!(str_square_index_rejected, "let s = \"abc\"; let c = s[0];");
+test_ty!(
+    optional_string_square_index,
+    "let s: str? = null;",
+    "s?[0]" => option!(Str),
+);
 test_fail!(
     str_square_index_by_str,
     "let s = \"abc\"; let c = s[\"k\"];"
 );
+test_fail!(string_index_assign, "let s = \"abc\"; s[0] = \"x\";");

--- a/crates/solve/src/traits/solve.rs
+++ b/crates/solve/src/traits/solve.rs
@@ -184,15 +184,20 @@ impl Solve for Access {
                 let k = key.query(solver)?;
                 let key_src = solver.src(location);
 
-                // caught before the shape below is unified against the receiver: `str` matches
-                // neither array nor dict, and letting that mismatch surface would name the
-                // shape's fresh vid, leaking an internal type into a user-facing message
-                if left.query(solver)?.normalized(solver) == Ty::Str {
-                    return Err(StringIndexing {
-                        src: solver.src(left.location()),
-                        at: left.location().into(),
+                // strings index by char position and never unify against the array/dict shape
+                // below; a non-int key gets its own error so the shape's fresh vid never leaks
+                // into a user-facing message
+                let receiver = left.query(solver)?.normalized(solver);
+                let optional = *kind == AccessKind::Option || rides(solver, left);
+                if receiver == Ty::Str || (optional && receiver == option!(Ty::Str)) {
+                    if k.normalized(solver) != Ty::Int {
+                        return Err(StringIndexing {
+                            src: solver.src(key.location()),
+                            at: key.location().into(),
+                        }
+                        .into());
                     }
-                    .into());
+                    return Ok(if optional { option!(Ty::Str) } else { Ty::Str });
                 }
 
                 let shape = |inner: Ty| -> Result<Ty> {

--- a/crates/vm/src/vm.rs
+++ b/crates/vm/src/vm.rs
@@ -928,10 +928,13 @@ fn get_index<'gc>(
         }
         (Val::Str(s), Val::Int(i)) => {
             let st = s.as_str();
-            let len = st.chars().count();
-            let p = pos(i, len)?;
-            let ch = st.chars().nth(p).ok_or(RtErr::IndexOutOfBounds)?;
-            Val::Str(ctx.intern(&ch.to_string()))
+            let ch = if st.is_ascii() {
+                st.as_bytes()[pos(i, st.len())?] as char
+            } else {
+                let p = pos(i, st.chars().count())?;
+                st.chars().nth(p).ok_or(RtErr::IndexOutOfBounds)?
+            };
+            Val::Str(ctx.intern(ch.encode_utf8(&mut [0; 4])))
         }
         (Val::Int(_), Val::Int(_)) => index,
         _ => return Err(RtErr::invalid_index(set, index)),


### PR DESCRIPTION
Indexing strings was already partly set up within the VM, filled in the rest so that the following is now possible:

```rust
const WORD = "foo";
assert_eq(WORD[0], "f");
```