### PR TITLE
feat: support order comparisons for strings

### DIFF
--- a/book/src/reference/operations.md
+++ b/book/src/reference/operations.md
@@ -26,19 +26,21 @@ Mixing an `int` and a `float` promotes the result to `float`. And `/` produces a
 
 ## Comparison
 
-Comparisons produce a `bool`. Ordering (`<`, `<=`, `>`, `>=`) is defined for numbers only; `str` supports equality but not ordering.
+Comparisons produce a `bool`. Ordering (`<`, `<=`, `>`, `>=`) is defined for numbers and for `str`. Strings are ordered by their UTF-8 bytes (relying on ordinary Rust string ordering comparisons).
 
 | Name | Symbol | Types |
 | :--- | :---: | :--- |
 | Equal | `==` | any matching pair |
 | Not equal | `!=` | any matching pair |
-| Less / less-or-equal | `<` `<=` | `int`, `float` |
-| Greater / greater-or-equal | `>` `>=` | `int`, `float` |
+| Less / less-or-equal | `<` `<=` | `int`, `float`, `str` |
+| Greater / greater-or-equal | `>` `>=` | `int`, `float`, `str` |
 
 ```mimas
-print(2 < 3);          // true
-print("hi" == "hi");   // true
-print("a" < "b");      // compile error: these values cannot be compared like numerals
+print(2 < 3);            // true
+print("hi" == "hi");     // true
+print("apple" < "pear"); // true
+print("Zoo" < "apple");  // true -- uppercase sorts first
+print("a" < 1);          // compile error: these types cannot be compared
 ```
 
 ## Logical

--- a/crates/library/tests/str.rs
+++ b/crates/library/tests/str.rs
@@ -54,6 +54,33 @@ test_fail!(
 
 test_fail!(index_assign, r#"let s = "abc"; s[0] = "x";"#);
 
+test_run!(
+    ordering_lexicographic,
+    r#""apple" < "banana""# => "true",
+    r#""banana" > "apple""# => "true",
+    r#""ab" < "abc""# => "true",
+    r#""abc" <= "abc""# => "true",
+    r#""abc" >= "abd""# => "false",
+    r#""Zebra" < "apple""# => "true",
+    r#""é" > "z""# => "true",
+);
+
+test_run!(
+    ordering_in_control_flow,
+    r#"let a = "pear"; let b = "plum";"#,
+    "if a < b { a } else { b }" => r#""pear""#,
+    r#"(for w in ["kiwi", "fig", "date"] { if w >= "e" collect w; })"# => r#"["kiwi", "fig"]"#,
+);
+
+test_run!(
+    ordering_in_consts,
+    r#"const LESS = "apple" < "pear"; const FLAGS = ["a" < "b", "b" <= "a"];"#,
+    "LESS" => "true",
+    "FLAGS" => "[true, false]",
+);
+
+test_fail!(ordering_mixed_types, r#"let x = "a" < 1;"#);
+
 // contains: substring test
 test_run!(
     contains_hit,

--- a/crates/solve/src/errors.rs
+++ b/crates/solve/src/errors.rs
@@ -602,7 +602,7 @@ pub struct InvalidAssignTarget {
 pub struct InvalidComparison {
     #[source_code]
     pub src: NamedSource<Arc<str>>,
-    #[label("these two values cannot be compared like numerals")]
+    #[label("these types cannot be compared")]
     pub at: SourceSpan,
 }
 

--- a/crates/solve/src/tests/solve_exprs.rs
+++ b/crates/solve/src/tests/solve_exprs.rs
@@ -210,7 +210,12 @@ test_ty!(
 );
 test_fail!(error_from_invalid_type_comp, "1 == true;");
 test_fail!(error_from_invalid_ord_comp, "1 > true;");
-test_fail!(string_ordering, "let a = \"a\" > \"b\";");
+test_ty!(string_ordering, "\"a\" > \"b\"" => Bool);
+test_fail!(string_int_ordering, "let a = \"a\" > 1;");
+test_fail!(
+    string_option_ordering,
+    "let s: str? = null; let a = s < \"b\";"
+);
 test_fail!(bool_ordering, "let a = true > false;");
 test_fail!(array_ordering, "let a = [] > [];");
 test_fail!(dict_ordering, "let a = ~{} > ~{};");

--- a/crates/solve/src/traits/solve.rs
+++ b/crates/solve/src/traits/solve.rs
@@ -970,6 +970,11 @@ impl Solve for Equality {
                     self.right.fulfill_ty(self.left.query(solver)?, solver)
                 }
             }
+            _ if lhs.clone().normalized(solver) == Ty::Str
+                && rhs.clone().normalized(solver) == Ty::Str =>
+            {
+                Ok(())
+            }
             _ => Err(InvalidComparison {
                 src: solver.src(location),
                 at: location.into(),

--- a/crates/solve/src/utils/reduce.rs
+++ b/crates/solve/src/utils/reduce.rs
@@ -229,7 +229,7 @@ fn evaluate(
 }
 
 fn compare(lhs: Literal, op: EqualityOp, rhs: Literal) -> Option<Literal> {
-    fn comp_floats(a: f64, op: EqualityOp, b: f64) -> Literal {
+    fn ordered<T: PartialOrd>(a: T, op: EqualityOp, b: T) -> Literal {
         match op {
             Greater if a > b => True,
             Greater => False,
@@ -255,8 +255,9 @@ fn compare(lhs: Literal, op: EqualityOp, rhs: Literal) -> Option<Literal> {
         NotEqual if lhs == rhs => Some(False),
         NotEqual if lhs != rhs => Some(True),
         _ => match (lhs, rhs) {
-            (Int(a), Int(b)) => Some(comp_floats(a as f64, op, b as f64)),
-            (Float(a), Float(b)) => Some(comp_floats(a, op, b)),
+            (Int(a), Int(b)) => Some(ordered(a as f64, op, b as f64)),
+            (Float(a), Float(b)) => Some(ordered(a, op, b)),
+            (String(a), String(b)) => Some(ordered(a, op, b)),
             _ => None,
         },
     }

--- a/crates/vm/src/val.rs
+++ b/crates/vm/src/val.rs
@@ -514,6 +514,10 @@ pub fn bin<'gc>(this: Val<'gc>, ctx: Ctx<'gc>, other: Val<'gc>, op: BinOp) -> Rt
             let combined = format!("{}{}", a.as_str(), b.as_str());
             Val::Str(ctx.intern(&combined))
         }
+        (BinOp::LessThan, Val::Str(a), Val::Str(b)) => Val::Bool(a.as_str() < b.as_str()),
+        (BinOp::LessEqual, Val::Str(a), Val::Str(b)) => Val::Bool(a.as_str() <= b.as_str()),
+        (BinOp::GreaterThan, Val::Str(a), Val::Str(b)) => Val::Bool(a.as_str() > b.as_str()),
+        (BinOp::GreaterEqual, Val::Str(a), Val::Str(b)) => Val::Bool(a.as_str() >= b.as_str()),
         (BinOp::Coalesce, Val::Null, other) => other,
         (BinOp::Coalesce, this, _) => this,
         (BinOp::NotEqual, left, right) => Val::Bool(left != right),


### PR DESCRIPTION
Enables usage of:
```rust
let a = "a";
let b = "b";
assert(a < b);
```
Uses underlying Rust string comparisons, so just ordered by UTF-8 bytes.