### PR TITLE
chore: bump rand to 0.10, adapt api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chompy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +277,15 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -424,13 +444,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -891,15 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,34 +973,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1334,12 +1339,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ colored = "2"
 pretty_assertions = "1.1"
 itertools = "0.10"
 hashbrown = { version = "0.13" }
-rand = "0.8"
+rand = "0.10"
 lazy_static = "1.4"
 bitflags = "1.3"
 chompy = "0.5"

--- a/crates/library/src/methods/array.rs
+++ b/crates/library/src/methods/array.rs
@@ -1,6 +1,6 @@
 use api::Intrinsic;
 use macros::native;
-use rand::seq::SliceRandom;
+use rand::{prelude::IndexedRandom, seq::SliceRandom};
 use shared::Ty;
 use vm::{Array, Ctx, RtErr, Val, anon, api::Api};
 
@@ -68,7 +68,7 @@ fn pop(arr: &mut Vec<anon::T<'gc>>) -> Option<anon::T<'gc>> {
 
 #[native]
 fn shuffle(arr: &mut Vec<anon::T<'gc>>) {
-    arr.shuffle(&mut rand::thread_rng());
+    arr.shuffle(&mut rand::rng());
 }
 
 // `other` stays as the gc handle because we already hold a borrow on `arr`. if `other`
@@ -100,7 +100,7 @@ fn flatten(arr: Vec<Vec<anon::T<'gc>>>) -> Vec<anon::T<'gc>> {
 
 #[native]
 fn choose(arr: &[Val<'gc>]) -> Option<anon::T<'gc>> {
-    arr.choose(&mut rand::thread_rng()).copied().map(anon::Anon)
+    arr.choose(&mut rand::rng()).copied().map(anon::Anon)
 }
 
 #[native]

--- a/crates/library/src/methods/bool.rs
+++ b/crates/library/src/methods/bool.rs
@@ -1,4 +1,5 @@
 use macros::native;
+use rand::RngExt;
 use shared::Ty;
 use vm::api::Api;
 
@@ -8,5 +9,5 @@ pub(crate) fn install<'gc>(api: &mut Api<'_, 'gc>) {
 
 #[native]
 fn random() -> bool {
-    rand::random()
+    rand::rng().random()
 }

--- a/crates/library/src/methods/float.rs
+++ b/crates/library/src/methods/float.rs
@@ -1,6 +1,6 @@
 use api::Intrinsic;
 use macros::native;
-use rand::Rng;
+use rand::RngExt;
 use shared::Ty;
 use vm::{RtErr, api::Api};
 
@@ -78,5 +78,5 @@ fn to_str<'gc>(n: f64) -> String {
 
 #[native]
 fn random<'gc>(len: f64) -> f64 {
-    rand::thread_rng().gen_range(0.0..len)
+    rand::rng().random_range(0.0..len)
 }

--- a/crates/library/src/methods/int.rs
+++ b/crates/library/src/methods/int.rs
@@ -1,6 +1,6 @@
 use api::Intrinsic;
 use macros::native;
-use rand::Rng;
+use rand::RngExt;
 use shared::Ty;
 use vm::{RtErr, api::Api};
 
@@ -45,7 +45,7 @@ fn to_str<'gc>(n: i64) -> String {
 
 #[native]
 fn random<'gc>(len: i64) -> i64 {
-    rand::thread_rng().gen_range(0..len)
+    rand::rng().random_range(0..len)
 }
 
 #[native]


### PR DESCRIPTION
Updates rand to use the new chacha API for considerable perf improvements.