### PR TITLE
fix: display struct/variant names instead of `@id` when printing

### DIFF
--- a/crates/compile/src/codegen/compiler.rs
+++ b/crates/compile/src/codegen/compiler.rs
@@ -546,12 +546,21 @@ impl Compiler {
             .map(|(&dec, &body)| (ir.resolutions.decs[dec].name.clone(), body))
             .collect();
 
+        let struct_names: IdVec<_, String> = ir
+            .resolutions
+            .adts
+            .values()
+            .map(|adt| adt.name.clone())
+            .collect::<Vec<_>>()
+            .into();
+
         Program {
             entry: BodyId::ZERO,
             chunks: std::mem::replace(&mut self.chunks, IdVec::new()),
             strs: ir.str_interner,
             bytes: bytes.finish(),
             items,
+            struct_names,
         }
     }
 }

--- a/crates/compile/src/codegen/program.rs
+++ b/crates/compile/src/codegen/program.rs
@@ -16,6 +16,9 @@ pub struct Program {
     pub strs: StrInterner,
     pub bytes: Vec<u8>,
     pub items: HashMap<String, BodyId>,
+    /// Struct/variant names, indexed by the same `AdtId`/`struct_id` that `NewInstance` and
+    /// runtime instances carry -- lets `print`/`display` show `Node { .. }` instead of `@3 { .. }`.
+    pub struct_names: IdVec<AdtId, String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/solve/src/resolutions.rs
+++ b/crates/solve/src/resolutions.rs
@@ -41,6 +41,7 @@ pub enum ResolvedDeclKind {
 }
 
 pub struct ResolvedAdt {
+    pub name: String,
     pub fields: Vec<String>,
     pub implements: Vec<PactId>,
     pub methods: IndexMap<String, DecId>,
@@ -78,6 +79,7 @@ impl ResolvedAdt {
         };
 
         Self {
+            name: adt.name.clone(),
             fields,
             implements,
             methods,

--- a/crates/vm/src/heap.rs
+++ b/crates/vm/src/heap.rs
@@ -67,6 +67,10 @@ pub struct State<'gc> {
     pub natives: Gc<'gc, RefLock<Vec<Option<crate::native::NativeRef<'gc>>>>>,
     pub mimas_bindings: Gc<'gc, RefLock<MimasBindings>>,
     pub fixtures: Gc<'gc, crate::fixtures::Fixtures>,
+    /// Struct/variant names indexed by `struct_id` (see [`InstanceData::struct_id`]), for
+    /// rendering instances as `Name { .. }` instead of `@id { .. }`. Filled in by
+    /// `Vm::load_program`.
+    pub struct_names: Gc<'gc, RefLock<Vec<String>>>,
 }
 
 impl<'gc> State<'gc> {
@@ -81,12 +85,14 @@ impl<'gc> State<'gc> {
         let natives = Gc::new(mc, RefLock::new(Vec::new()));
         let mimas_bindings = Gc::new(mc, RefLock::new(MimasBindings::default()));
         let fixtures = Gc::new(mc, crate::fixtures::Fixtures::default());
+        let struct_names = Gc::new(mc, RefLock::new(Vec::new()));
         State {
             strings: InternedStrings::new(mc),
             thread,
             natives,
             mimas_bindings,
             fixtures,
+            struct_names,
         }
     }
 
@@ -266,7 +272,15 @@ impl<'gc> Ctx<'gc> {
                     .map(|v| self.display(v))
                     .collect::<Vec<_>>()
                     .join(", ");
-                let _ = write!(out, "@{} {{ {} }}", inst.struct_id, entries);
+                let names = self.state.struct_names.borrow();
+                match names.get(inst.struct_id as usize) {
+                    Some(name) => {
+                        let _ = write!(out, "{name} {{ {entries} }}");
+                    }
+                    None => {
+                        let _ = write!(out, "@{} {{ {} }}", inst.struct_id, entries);
+                    }
+                }
             }
         }
     }

--- a/crates/vm/src/vm.rs
+++ b/crates/vm/src/vm.rs
@@ -80,6 +80,7 @@ impl Vm {
             strs,
             bytes,
             items,
+            struct_names,
         } = program;
         self.entry = entry;
         self.code = Decoder { bytes, ip: 0 };
@@ -101,6 +102,7 @@ impl Vm {
                 return_reg: 0,
                 base: 0,
             });
+            *state.struct_names.borrow_mut(mc) = struct_names.into_values().collect();
         });
     }
 

--- a/crates/vm/tests/types.rs
+++ b/crates/vm/tests/types.rs
@@ -45,3 +45,27 @@ test_vm!(
      let w = make(7);",
     "if let Wrap(x) = w { x } else { -1 }" => Int(7),
 );
+
+// `print`/`display`/f-strings render an instance as `Name { .. }`, not the bare `@id { .. }`
+// the runtime used to fall back to before struct/variant names were threaded through to the VM.
+test_vm!(
+    instance_display_uses_struct_name,
+    "struct Node { next: Node?, prev: Node?, val: int }
+     let n = Node { next = null, prev = null, val = 3 };",
+    r#"f"{n}""# => str!("Node { null, null, 3 }"),
+);
+
+test_vm!(
+    tuple_struct_display_uses_struct_name,
+    "struct Wrap(int);
+     let w = Wrap(9);",
+    r#"f"{w}""# => str!("Wrap { 9 }"),
+);
+
+// enum variant instances display qualified as `Enum::Variant { .. }`
+test_vm!(
+    enum_variant_display_uses_qualified_name,
+    "enum Shape { Circle { radius: int }, Square(int) }",
+    r#"f"{Shape::Circle { radius = 5 }}""# => str!("Shape::Circle { 5 }"),
+    r#"f"{Shape::Square(4)}""# => str!("Shape::Square { 4 }"),
+);

--- a/crates/vm/tests/vm_test_utils.rs
+++ b/crates/vm/tests/vm_test_utils.rs
@@ -52,8 +52,10 @@ macro_rules! dict {
     }};
 }
 
-// the struct name is accepted for readability but ignored at comparison time (the runtime
-// only carries a numeric struct_id, not a name -- see task #18); fields compare positionally
+// the struct name is accepted for readability but ignored at comparison time -- `Captured`
+// compares instance fields positionally, with no name involved. The runtime does now carry
+// struct/variant names (used by `print`/`display`/f-strings, see types.rs's display tests);
+// this macro just never needed them for equality.
 #[macro_export]
 macro_rules! instance {
     ( $name:ident { $($field:ident = $val:expr),* $(,)? } ) => {{


### PR DESCRIPTION
`UserType { val = 3 }` now prints as `UserType { 3 }` instead of `@19 { 3 }`. This seems to fix a task named "#14" though no entries on the GitHub bug tracker!

I can remove the LLM comments to taste but I always liked docstrings over no docstrings!